### PR TITLE
Signer trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 license = "GPL-3.0-or-later"
 
 [dependencies]
+async-trait = "0.1"
+futures = "0.3"
 lazy_static = "1.4"
 rpassword = "4.0"
 secstr = "0.3"
@@ -16,6 +18,7 @@ sodiumoxide = "0.2"
 thiserror = "1.0"
 
 [dev-dependencies]
+async-std = { version = "1", features = ["attributes"] }
 ed25519-dalek = "1.0.0-pre.3" # lolwut?
 rand = "0.7"
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,7 @@ sodiumoxide = "0.2"
 thiserror = "1.0"
 
 [dev-dependencies]
-tempfile = "3.1"
+ed25519-dalek = "1.0.0-pre.3" # lolwut?
+rand = "0.7"
+tempfile = "3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,5 @@ thiserror = "1.0"
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes"] }
 ed25519-dalek = "1.0.0-pre.3" # lolwut?
-rand = "0.7"
 tempfile = "3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,6 @@ authors = ["The Radicle Team <dev@radicle.xyz>"]
 edition = "2018"
 license = "GPL-3.0-or-later"
 
-[features]
-default = []
-ssh = ["anyhow", "cryptovec", "futures", "thrussh-keys", "tokio"]
-
 [dependencies]
 lazy_static = "1.4"
 rpassword = "4.0"
@@ -18,13 +14,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.10"
 sodiumoxide = "0.2"
 thiserror = "1.0"
-
-# optionals for ssh feature
-anyhow = { version = "1.0", optional = true }
-cryptovec = { version = "0.5", optional = true }
-futures = { version = "0.3", optional = true }
-thrussh-keys = { version = "0.17", optional = true }
-tokio = { version = "0.2", features = ["blocking"],  optional = true }
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ authors = ["The Radicle Team <dev@radicle.xyz>"]
 edition = "2018"
 license = "GPL-3.0-or-later"
 
+[features]
+default = []
+ssh = ["anyhow", "cryptovec", "futures", "thrussh-keys", "tokio"]
+
 [dependencies]
 lazy_static = "1.4"
 rpassword = "4.0"
@@ -14,6 +18,13 @@ serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.10"
 sodiumoxide = "0.2"
 thiserror = "1.0"
+
+# optionals for ssh feature
+anyhow = { version = "1.0", optional = true }
+cryptovec = { version = "0.5", optional = true }
+futures = { version = "0.3", optional = true }
+thrussh-keys = { version = "0.17", optional = true }
+tokio = { version = "0.2", features = ["blocking"],  optional = true }
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,10 @@
 //! employed by [`crypto::Pwhash`]) in some system keychain, or offload
 //! encryption entirely to an external system (such as GPG, or a password
 //! manager).
+
+#[macro_use]
+extern crate async_trait;
+
 pub use secstr::SecStr;
 
 pub mod crypto;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub mod crypto;
 pub mod file;
 pub mod memory;
 pub mod pinentry;
+pub mod sign;
 
 #[cfg(test)]
 pub(crate) mod test;

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -1,0 +1,169 @@
+// This file is part of radicle-link
+// <https://github.com/radicle-dev/radicle-link>
+//
+// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use std::convert::Infallible;
+
+use sodiumoxide::crypto::sign::ed25519;
+
+use crate::Keypair;
+#[cfg(feature = "ssh")]
+pub use ssh::*;
+
+pub trait Signer {
+    type PublicKey;
+    type Signature;
+
+    type Error;
+
+    fn public_key(&self) -> &Self::PublicKey;
+    fn sign(&mut self, data: &[u8]) -> Result<Self::Signature, Self::Error>;
+}
+
+impl Signer for Keypair<ed25519::PublicKey, ed25519::SecretKey> {
+    type PublicKey = ed25519::PublicKey;
+    type Signature = ed25519::Signature;
+
+    type Error = Infallible;
+
+    fn public_key(&self) -> &Self::PublicKey {
+        &self.public_key
+    }
+
+    fn sign(&mut self, data: &[u8]) -> Result<Self::Signature, Self::Error> {
+        Ok(ed25519::sign_detached(data, &self.secret_key))
+    }
+}
+
+#[cfg(feature = "ssh")]
+mod ssh {
+    use super::*;
+
+    use std::cell::RefCell;
+
+    pub use cryptovec::CryptoVec;
+    use futures::executor::block_on;
+    use thrussh_keys::agent::client::AgentClient;
+    use tokio::io::{AsyncRead, AsyncWrite};
+
+    pub struct SshAgent<S: AsyncRead + AsyncWrite> {
+        public_key: thrussh_keys::key::PublicKey,
+        client: RefCell<Option<AgentClient<S>>>,
+    }
+
+    impl<S: AsyncRead + AsyncWrite> SshAgent<S> {
+        pub fn new<K: Into<thrussh_keys::key::PublicKey>>(
+            public_key: K,
+            client: AgentClient<S>,
+        ) -> Self {
+            Self {
+                public_key: public_key.into(),
+                client: RefCell::new(Some(client)),
+            }
+        }
+    }
+
+    impl<S> Signer for SshAgent<S>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        type PublicKey = thrussh_keys::key::PublicKey;
+        type Signature = CryptoVec;
+        type Error = anyhow::Error;
+
+        fn public_key(&self) -> &Self::PublicKey {
+            &self.public_key
+        }
+
+        fn sign(&mut self, data: &[u8]) -> Result<Self::Signature, Self::Error> {
+            match self.client.replace(None) {
+                Some(client) => {
+                    self.client.replace(None);
+                    let data = CryptoVec::from(Vec::from(data));
+                    let (client, result) = block_on(client.sign_request(&self.public_key, data));
+                    let _ = self.client.replace(Some(client));
+                    result
+                },
+                None => unreachable!(),
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        use std::future::Future;
+
+        use tempfile::tempdir;
+        use thrussh_keys::*;
+
+        #[derive(Clone)]
+        struct X {}
+        impl agent::server::Agent for X {
+            fn confirm(
+                self,
+                _: std::sync::Arc<key::KeyPair>,
+            ) -> Box<dyn Future<Output = (Self, bool)> + Send + Unpin> {
+                Box::new(futures::future::ready((self, true)))
+            }
+        }
+
+        const PKCS8_ENCRYPTED: &'static str = "-----BEGIN ENCRYPTED PRIVATE KEY-----\nMIIFLTBXBgkqhkiG9w0BBQ0wSjApBgkqhkiG9w0BBQwwHAQITo1O0b8YrS0CAggA\nMAwGCCqGSIb3DQIJBQAwHQYJYIZIAWUDBAEqBBBtLH4T1KOfo1GGr7salhR8BIIE\n0KN9ednYwcTGSX3hg7fROhTw7JAJ1D4IdT1fsoGeNu2BFuIgF3cthGHe6S5zceI2\nMpkfwvHbsOlDFWMUIAb/VY8/iYxhNmd5J6NStMYRC9NC0fVzOmrJqE1wITqxtORx\nIkzqkgFUbaaiFFQPepsh5CvQfAgGEWV329SsTOKIgyTj97RxfZIKA+TR5J5g2dJY\nj346SvHhSxJ4Jc0asccgMb0HGh9UUDzDSql0OIdbnZW5KzYJPOx+aDqnpbz7UzY/\nP8N0w/pEiGmkdkNyvGsdttcjFpOWlLnLDhtLx8dDwi/sbEYHtpMzsYC9jPn3hnds\nTcotqjoSZ31O6rJD4z18FOQb4iZs3MohwEdDd9XKblTfYKM62aQJWH6cVQcg+1C7\njX9l2wmyK26Tkkl5Qg/qSfzrCveke5muZgZkFwL0GCcgPJ8RixSB4GOdSMa/hAMU\nkvFAtoV2GluIgmSe1pG5cNMhurxM1dPPf4WnD+9hkFFSsMkTAuxDZIdDk3FA8zof\nYhv0ZTfvT6V+vgH3Hv7Tqcxomy5Qr3tj5vvAqqDU6k7fC4FvkxDh2mG5ovWvc4Nb\nXv8sed0LGpYitIOMldu6650LoZAqJVv5N4cAA2Edqldf7S2Iz1QnA/usXkQd4tLa\nZ80+sDNv9eCVkfaJ6kOVLk/ghLdXWJYRLenfQZtVUXrPkaPpNXgD0dlaTN8KuvML\nUw/UGa+4ybnPsdVflI0YkJKbxouhp4iB4S5ACAwqHVmsH5GRnujf10qLoS7RjDAl\no/wSHxdT9BECp7TT8ID65u2mlJvH13iJbktPczGXt07nBiBse6OxsClfBtHkRLzE\nQF6UMEXsJnIIMRfrZQnduC8FUOkfPOSXc8r9SeZ3GhfbV/DmWZvFPCpjzKYPsM5+\nN8Bw/iZ7NIH4xzNOgwdp5BzjH9hRtCt4sUKVVlWfEDtTnkHNOusQGKu7HkBF87YZ\nRN/Nd3gvHob668JOcGchcOzcsqsgzhGMD8+G9T9oZkFCYtwUXQU2XjMN0R4VtQgZ\nrAxWyQau9xXMGyDC67gQ5xSn+oqMK0HmoW8jh2LG/cUowHFAkUxdzGadnjGhMOI2\nzwNJPIjF93eDF/+zW5E1l0iGdiYyHkJbWSvcCuvTwma9FIDB45vOh5mSR+YjjSM5\nnq3THSWNi7Cxqz12Q1+i9pz92T2myYKBBtu1WDh+2KOn5DUkfEadY5SsIu/Rb7ub\n5FBihk2RN3y/iZk+36I69HgGg1OElYjps3D+A9AjVby10zxxLAz8U28YqJZm4wA/\nT0HLxBiVw+rsHmLP79KvsT2+b4Diqih+VTXouPWC/W+lELYKSlqnJCat77IxgM9e\nYIhzD47OgWl33GJ/R10+RDoDvY4koYE+V5NLglEhbwjloo9Ryv5ywBJNS7mfXMsK\n/uf+l2AscZTZ1mhtL38efTQCIRjyFHc3V31DI0UdETADi+/Omz+bXu0D5VvX+7c6\nb1iVZKpJw8KUjzeUV8yOZhvGu3LrQbhkTPVYL555iP1KN0Eya88ra+FUKMwLgjYr\nJkUx4iad4dTsGPodwEP/Y9oX/Qk3ZQr+REZ8lg6IBoKKqqrQeBJ9gkm1jfKE6Xkc\nCog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux\n-----END ENCRYPTED PRIVATE KEY-----\n";
+
+        #[test]
+        fn test_sign() {
+            let tmp = tempdir().unwrap();
+            let agent_path = tmp.path().join("agent");
+
+            let mut rt = tokio::runtime::Runtime::new().unwrap();
+
+            let agent_path_ = agent_path.clone();
+
+            // Starting a server
+            rt.spawn(async move {
+                let mut listener = tokio::net::UnixListener::bind(&agent_path_).unwrap();
+                thrussh_keys::agent::server::serve(listener.incoming(), X {}).await
+            });
+
+            let key = decode_secret_key(PKCS8_ENCRYPTED, Some(b"blabla")).unwrap();
+            let public = key.clone_public_key();
+
+            let res = rt
+                .block_on(async move {
+                    let stream = tokio::net::UnixStream::connect(&agent_path).await?;
+                    let mut client = agent::client::AgentClient::connect(stream);
+                    client
+                        .add_identity(&key, &[agent::Constraint::KeyLifetime { seconds: 60 }])
+                        .await?;
+                    client.request_identities().await?;
+
+                    let mut agent_signer = SshAgent::new(public, client);
+
+                    let buf = b"signed message";
+                    let sig = agent_signer.sign(buf).unwrap();
+                    println!("{:?}", sig);
+
+                    Ok::<bool, anyhow::Error>(
+                        agent_signer.public_key().verify_detached(buf, sig.as_ref()),
+                    )
+                })
+                .unwrap();
+
+            assert!(res)
+        }
+    }
+}

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -21,6 +21,7 @@ pub mod ed25519 {
     use std::{
         cmp::Ordering,
         convert::Infallible,
+        fmt::{self, Debug},
         hash::{Hash, Hasher},
     };
 
@@ -85,6 +86,12 @@ pub mod ed25519 {
         #[inline]
         fn cmp(&self, other: &Signature) -> Ordering {
             Ord::cmp(self.as_ref(), other.as_ref())
+        }
+    }
+
+    impl Debug for Signature {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "Signature({:?})", self.as_ref())
         }
     }
 

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -15,155 +15,99 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::convert::Infallible;
+pub use ed25519::*;
 
-use sodiumoxide::crypto::sign::ed25519;
+pub mod ed25519 {
+    use std::{
+        cmp::Ordering,
+        convert::Infallible,
+        hash::{Hash, Hasher},
+    };
 
-use crate::Keypair;
-#[cfg(feature = "ssh")]
-pub use ssh::*;
+    use sodiumoxide::{crypto::sign::ed25519, utils};
 
-pub trait Signer {
-    type PublicKey;
-    type Signature;
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    pub struct PublicKey(pub [u8; 32]);
 
-    type Error;
-
-    fn public_key(&self) -> &Self::PublicKey;
-    fn sign(&mut self, data: &[u8]) -> Result<Self::Signature, Self::Error>;
-}
-
-impl Signer for Keypair<ed25519::PublicKey, ed25519::SecretKey> {
-    type PublicKey = ed25519::PublicKey;
-    type Signature = ed25519::Signature;
-
-    type Error = Infallible;
-
-    fn public_key(&self) -> &Self::PublicKey {
-        &self.public_key
-    }
-
-    fn sign(&mut self, data: &[u8]) -> Result<Self::Signature, Self::Error> {
-        Ok(ed25519::sign_detached(data, &self.secret_key))
-    }
-}
-
-#[cfg(feature = "ssh")]
-mod ssh {
-    use super::*;
-
-    use std::cell::RefCell;
-
-    pub use cryptovec::CryptoVec;
-    use futures::executor::block_on;
-    use thrussh_keys::agent::client::AgentClient;
-    use tokio::io::{AsyncRead, AsyncWrite};
-
-    pub struct SshAgent<S: AsyncRead + AsyncWrite> {
-        public_key: thrussh_keys::key::PublicKey,
-        client: RefCell<Option<AgentClient<S>>>,
-    }
-
-    impl<S: AsyncRead + AsyncWrite> SshAgent<S> {
-        pub fn new<K: Into<thrussh_keys::key::PublicKey>>(
-            public_key: K,
-            client: AgentClient<S>,
-        ) -> Self {
-            Self {
-                public_key: public_key.into(),
-                client: RefCell::new(Some(client)),
-            }
+    impl AsRef<[u8]> for PublicKey {
+        fn as_ref(&self) -> &[u8] {
+            &self.0
         }
     }
 
-    impl<S> Signer for SshAgent<S>
-    where
-        S: AsyncRead + AsyncWrite + Unpin,
-    {
-        type PublicKey = thrussh_keys::key::PublicKey;
-        type Signature = CryptoVec;
-        type Error = anyhow::Error;
+    #[derive(Clone, Copy)]
+    pub struct Signature(pub [u8; 64]);
 
-        fn public_key(&self) -> &Self::PublicKey {
-            &self.public_key
-        }
-
-        fn sign(&mut self, data: &[u8]) -> Result<Self::Signature, Self::Error> {
-            match self.client.replace(None) {
-                Some(client) => {
-                    self.client.replace(None);
-                    let data = CryptoVec::from(Vec::from(data));
-                    let (client, result) = block_on(client.sign_request(&self.public_key, data));
-                    let _ = self.client.replace(Some(client));
-                    result
-                },
-                None => unreachable!(),
-            }
+    impl PartialEq for Signature {
+        fn eq(&self, other: &Self) -> bool {
+            utils::memcmp(&self.0, &other.0)
         }
     }
 
-    #[cfg(test)]
-    mod tests {
-        use super::*;
+    impl Eq for Signature {}
 
-        use std::future::Future;
+    impl AsRef<[u8]> for Signature {
+        fn as_ref(&self) -> &[u8] {
+            &self.0
+        }
+    }
 
-        use tempfile::tempdir;
-        use thrussh_keys::*;
+    impl Hash for Signature {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            Hash::hash(self.as_ref(), state)
+        }
+    }
 
-        #[derive(Clone)]
-        struct X {}
-        impl agent::server::Agent for X {
-            fn confirm(
-                self,
-                _: std::sync::Arc<key::KeyPair>,
-            ) -> Box<dyn Future<Output = (Self, bool)> + Send + Unpin> {
-                Box::new(futures::future::ready((self, true)))
-            }
+    impl PartialOrd for Signature {
+        #[inline]
+        fn partial_cmp(&self, other: &Signature) -> Option<Ordering> {
+            PartialOrd::partial_cmp(self.as_ref(), other.as_ref())
+        }
+        #[inline]
+        fn lt(&self, other: &Signature) -> bool {
+            PartialOrd::lt(self.as_ref(), other.as_ref())
+        }
+        #[inline]
+        fn le(&self, other: &Signature) -> bool {
+            PartialOrd::le(self.as_ref(), other.as_ref())
+        }
+        #[inline]
+        fn ge(&self, other: &Signature) -> bool {
+            PartialOrd::ge(self.as_ref(), other.as_ref())
+        }
+        #[inline]
+        fn gt(&self, other: &Signature) -> bool {
+            PartialOrd::gt(self.as_ref(), other.as_ref())
+        }
+    }
+
+    impl Ord for Signature {
+        #[inline]
+        fn cmp(&self, other: &Signature) -> Ordering {
+            Ord::cmp(self.as_ref(), other.as_ref())
+        }
+    }
+
+    pub trait Signer {
+        type Error;
+
+        /// Obtain the [`PublicKey`] used for signing
+        fn public_key(&self) -> PublicKey;
+
+        /// Sign the supplied data with the secret key corresponding to
+        /// [`Signer::public_key`]
+        fn sign(&mut self, data: &[u8]) -> Result<Signature, Self::Error>;
+    }
+
+    impl Signer for (ed25519::PublicKey, ed25519::SecretKey) {
+        type Error = Infallible;
+
+        fn public_key(&self) -> PublicKey {
+            PublicKey((self.0).0)
         }
 
-        const PKCS8_ENCRYPTED: &'static str = "-----BEGIN ENCRYPTED PRIVATE KEY-----\nMIIFLTBXBgkqhkiG9w0BBQ0wSjApBgkqhkiG9w0BBQwwHAQITo1O0b8YrS0CAggA\nMAwGCCqGSIb3DQIJBQAwHQYJYIZIAWUDBAEqBBBtLH4T1KOfo1GGr7salhR8BIIE\n0KN9ednYwcTGSX3hg7fROhTw7JAJ1D4IdT1fsoGeNu2BFuIgF3cthGHe6S5zceI2\nMpkfwvHbsOlDFWMUIAb/VY8/iYxhNmd5J6NStMYRC9NC0fVzOmrJqE1wITqxtORx\nIkzqkgFUbaaiFFQPepsh5CvQfAgGEWV329SsTOKIgyTj97RxfZIKA+TR5J5g2dJY\nj346SvHhSxJ4Jc0asccgMb0HGh9UUDzDSql0OIdbnZW5KzYJPOx+aDqnpbz7UzY/\nP8N0w/pEiGmkdkNyvGsdttcjFpOWlLnLDhtLx8dDwi/sbEYHtpMzsYC9jPn3hnds\nTcotqjoSZ31O6rJD4z18FOQb4iZs3MohwEdDd9XKblTfYKM62aQJWH6cVQcg+1C7\njX9l2wmyK26Tkkl5Qg/qSfzrCveke5muZgZkFwL0GCcgPJ8RixSB4GOdSMa/hAMU\nkvFAtoV2GluIgmSe1pG5cNMhurxM1dPPf4WnD+9hkFFSsMkTAuxDZIdDk3FA8zof\nYhv0ZTfvT6V+vgH3Hv7Tqcxomy5Qr3tj5vvAqqDU6k7fC4FvkxDh2mG5ovWvc4Nb\nXv8sed0LGpYitIOMldu6650LoZAqJVv5N4cAA2Edqldf7S2Iz1QnA/usXkQd4tLa\nZ80+sDNv9eCVkfaJ6kOVLk/ghLdXWJYRLenfQZtVUXrPkaPpNXgD0dlaTN8KuvML\nUw/UGa+4ybnPsdVflI0YkJKbxouhp4iB4S5ACAwqHVmsH5GRnujf10qLoS7RjDAl\no/wSHxdT9BECp7TT8ID65u2mlJvH13iJbktPczGXt07nBiBse6OxsClfBtHkRLzE\nQF6UMEXsJnIIMRfrZQnduC8FUOkfPOSXc8r9SeZ3GhfbV/DmWZvFPCpjzKYPsM5+\nN8Bw/iZ7NIH4xzNOgwdp5BzjH9hRtCt4sUKVVlWfEDtTnkHNOusQGKu7HkBF87YZ\nRN/Nd3gvHob668JOcGchcOzcsqsgzhGMD8+G9T9oZkFCYtwUXQU2XjMN0R4VtQgZ\nrAxWyQau9xXMGyDC67gQ5xSn+oqMK0HmoW8jh2LG/cUowHFAkUxdzGadnjGhMOI2\nzwNJPIjF93eDF/+zW5E1l0iGdiYyHkJbWSvcCuvTwma9FIDB45vOh5mSR+YjjSM5\nnq3THSWNi7Cxqz12Q1+i9pz92T2myYKBBtu1WDh+2KOn5DUkfEadY5SsIu/Rb7ub\n5FBihk2RN3y/iZk+36I69HgGg1OElYjps3D+A9AjVby10zxxLAz8U28YqJZm4wA/\nT0HLxBiVw+rsHmLP79KvsT2+b4Diqih+VTXouPWC/W+lELYKSlqnJCat77IxgM9e\nYIhzD47OgWl33GJ/R10+RDoDvY4koYE+V5NLglEhbwjloo9Ryv5ywBJNS7mfXMsK\n/uf+l2AscZTZ1mhtL38efTQCIRjyFHc3V31DI0UdETADi+/Omz+bXu0D5VvX+7c6\nb1iVZKpJw8KUjzeUV8yOZhvGu3LrQbhkTPVYL555iP1KN0Eya88ra+FUKMwLgjYr\nJkUx4iad4dTsGPodwEP/Y9oX/Qk3ZQr+REZ8lg6IBoKKqqrQeBJ9gkm1jfKE6Xkc\nCog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux\n-----END ENCRYPTED PRIVATE KEY-----\n";
-
-        #[test]
-        fn test_sign() {
-            let tmp = tempdir().unwrap();
-            let agent_path = tmp.path().join("agent");
-
-            let mut rt = tokio::runtime::Runtime::new().unwrap();
-
-            let agent_path_ = agent_path.clone();
-
-            // Starting a server
-            rt.spawn(async move {
-                let mut listener = tokio::net::UnixListener::bind(&agent_path_).unwrap();
-                thrussh_keys::agent::server::serve(listener.incoming(), X {}).await
-            });
-
-            let key = decode_secret_key(PKCS8_ENCRYPTED, Some(b"blabla")).unwrap();
-            let public = key.clone_public_key();
-
-            let res = rt
-                .block_on(async move {
-                    let stream = tokio::net::UnixStream::connect(&agent_path).await?;
-                    let mut client = agent::client::AgentClient::connect(stream);
-                    client
-                        .add_identity(&key, &[agent::Constraint::KeyLifetime { seconds: 60 }])
-                        .await?;
-                    client.request_identities().await?;
-
-                    let mut agent_signer = SshAgent::new(public, client);
-
-                    let buf = b"signed message";
-                    let sig = agent_signer.sign(buf).unwrap();
-                    println!("{:?}", sig);
-
-                    Ok::<bool, anyhow::Error>(
-                        agent_signer.public_key().verify_detached(buf, sig.as_ref()),
-                    )
-                })
-                .unwrap();
-
-            assert!(res)
+        fn sign(&mut self, data: &[u8]) -> Result<Signature, Self::Error> {
+            Ok(Signature(ed25519::sign_detached(data, &self.1).0))
         }
     }
 }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -25,7 +25,7 @@ pub mod ed25519 {
         hash::{Hash, Hasher},
     };
 
-    use sodiumoxide::{crypto::sign::ed25519, utils};
+    use sodiumoxide::utils;
 
     #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct PublicKey(pub [u8; 32]);
@@ -106,7 +106,12 @@ pub mod ed25519 {
         fn sign(&mut self, data: &[u8]) -> Result<Signature, Self::Error>;
     }
 
-    impl Signer for (ed25519::PublicKey, ed25519::SecretKey) {
+    impl Signer
+        for (
+            sodiumoxide::crypto::sign::ed25519::PublicKey,
+            sodiumoxide::crypto::sign::ed25519::SecretKey,
+        )
+    {
         type Error = Infallible;
 
         fn public_key(&self) -> PublicKey {
@@ -114,7 +119,9 @@ pub mod ed25519 {
         }
 
         fn sign(&mut self, data: &[u8]) -> Result<Signature, Self::Error> {
-            Ok(Signature(ed25519::sign_detached(data, &self.1).0))
+            Ok(Signature(
+                sodiumoxide::crypto::sign::ed25519::sign_detached(data, &self.1).0,
+            ))
         }
     }
 }

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -103,7 +103,7 @@ pub mod ed25519 {
 
         /// Sign the supplied data with the secret key corresponding to
         /// [`Signer::public_key`]
-        fn sign(&mut self, data: &[u8]) -> Result<Signature, Self::Error>;
+        fn sign(&self, data: &[u8]) -> Result<Signature, Self::Error>;
     }
 
     impl Signer
@@ -118,10 +118,96 @@ pub mod ed25519 {
             PublicKey((self.0).0)
         }
 
-        fn sign(&mut self, data: &[u8]) -> Result<Signature, Self::Error> {
+        fn sign(&self, data: &[u8]) -> Result<Signature, Self::Error> {
             Ok(Signature(
                 sodiumoxide::crypto::sign::ed25519::sign_detached(data, &self.1).0,
             ))
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        use rand::rngs::OsRng;
+        use sodiumoxide::crypto::sign as sodium;
+
+        const MESSAGE: &[u8] = b"in a bottle";
+
+        struct Roundtrip<S, V> {
+            signer: S,
+            verifier: V,
+        }
+
+        /// Base compatibility test.
+        ///
+        /// Given two `Signer` implementations, we assert that a signature
+        /// produced by one can be verified by the other. Conversions of
+        /// `Signature` and `PublicKey` are up to the implementations --
+        /// hence, we implicitly assert compatibility between the encodings.
+        ///
+        /// All combinatorial pairs of `Signer` implementations should pass
+        /// this.
+        fn compat<S1, S2, V1, V2>(roundtrip1: Roundtrip<S1, V1>, roundtrip2: Roundtrip<S2, V2>)
+        where
+            S1: Signer,
+            S2: Signer,
+            V1: FnOnce(&Signature, &PublicKey) -> bool,
+            V2: FnOnce(&Signature, &PublicKey) -> bool,
+
+            S1::Error: Debug,
+            S2::Error: Debug,
+        {
+            let sig1 = (roundtrip1.signer).sign(MESSAGE).unwrap();
+            let sig2 = (roundtrip2.signer).sign(MESSAGE).unwrap();
+            assert!(
+                (roundtrip1.verifier)(&sig2, &(roundtrip2.signer).public_key()),
+                "signature produced by signer1 could not be verified by signer2"
+            );
+            assert!(
+                (roundtrip2.verifier)(&sig1, &(roundtrip1.signer).public_key()),
+                "signature produced by signer2 could not be verified by signer1"
+            );
+        }
+
+        impl Signer for ed25519_dalek::Keypair {
+            type Error = Infallible;
+
+            fn public_key(&self) -> PublicKey {
+                PublicKey(self.public.to_bytes())
+            }
+
+            fn sign(&self, data: &[u8]) -> Result<Signature, Self::Error> {
+                let signer: &ed25519_dalek::Keypair = self;
+                Ok(Signature(signer.sign(data).to_bytes()))
+            }
+        }
+
+        #[test]
+        fn compat_sodium_dalek() {
+            sodiumoxide::init().unwrap();
+            compat(
+                Roundtrip {
+                    signer: sodium::gen_keypair(),
+                    verifier: |sig: &Signature, pk: &PublicKey| {
+                        let sig = sodium::Signature::from_slice(sig.as_ref())
+                            .expect("does not look like a sodium ed25519 signature");
+                        let pk = sodium::PublicKey::from_slice(pk.as_ref())
+                            .expect("does not look like a sodium ed25519 public key");
+
+                        sodium::verify_detached(&sig, MESSAGE, &pk)
+                    },
+                },
+                Roundtrip {
+                    signer: ed25519_dalek::Keypair::generate(&mut OsRng {}),
+                    verifier: |sig: &Signature, pk: &PublicKey| {
+                        let sig = ed25519_dalek::Signature::from_bytes(sig.as_ref()).unwrap();
+                        let pk = ed25519_dalek::PublicKey::from_bytes(pk.as_ref()).unwrap();
+
+                        pk.verify(MESSAGE, &sig).and(Ok(true)).unwrap()
+                    },
+                },
+            )
         }
     }
 }


### PR DESCRIPTION
This is an attempt to formulate the `Signer` abstraction as per https://github.com/radicle-dev/radicle-upstream/pull/507#discussion_r441348937

There are a plethora of problems, which I don't currently have an idea how to solve:

* We will want to parametrise the trait over the signature algorithm, somehow

    The idea is that all implementations should produce the same result, yet if anything is to evolve, then that we'd need a different algorithm (for whatever purpose). I don't really know how to achieve this, except if the trait is "sealed" in that no implementations outside of this crate are possible. That is, the public key and signature types need to be defined here, with no constructors exported

* `async/await` sucks

    Yeah well, idk. Given that any external signer would require IO, maybe it'd be alright to define this as an `async_trait`.

* `thrussh-keys` is actually broken

   This seems to be the only Rust library with support for the `SSH_AGENT_SIGN_REQUEST` operations, but the returned signature doesn't actually verify. It also has a somewhat strange API which always consumes and then returns `self` in inconsistent ways. Perhaps it could be fixed, but I can't seem to use my pijul nest account, nor create a new one.