### PR TITLE
Add impl Signer for sodiumoxide SecretKey

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,6 @@ thiserror = "1.0"
 
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes"] }
-ed25519-dalek = "1.0.0-pre.3" # lolwut?
+ed25519-dalek = "=1.0.0-pre.4" # lolwut?
 tempfile = "3"
 

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -128,24 +128,6 @@ pub mod ed25519 {
         }
     }
 
-    #[async_trait]
-    impl Signer
-        for (
-            sodiumoxide::crypto::sign::ed25519::PublicKey,
-            sodiumoxide::crypto::sign::ed25519::SecretKey,
-        )
-    {
-        type Error = Infallible;
-
-        fn public_key(&self) -> PublicKey {
-            PublicKey((self.0).0)
-        }
-
-        async fn sign(&self, data: &[u8]) -> Result<Signature, Self::Error> {
-            self.1.sign(data).await
-        }
-    }
-
     #[cfg(test)]
     mod tests {
         use super::*;
@@ -193,9 +175,9 @@ pub mod ed25519 {
         async fn compat_sodium_dalek() {
             sodiumoxide::init().unwrap();
 
-            let sodium = sodium::gen_keypair();
+            let (_, sodium) = sodium::gen_keypair();
             let dalek = {
-                let secret = ed25519_dalek::SecretKey::from_bytes(&sodium.1[..32]).unwrap();
+                let secret = ed25519_dalek::SecretKey::from_bytes(&sodium[..32]).unwrap();
                 let public = ed25519_dalek::PublicKey::from(&secret);
                 ed25519_dalek::Keypair { secret, public }
             };

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -114,6 +114,21 @@ pub mod ed25519 {
     }
 
     #[async_trait]
+    impl Signer for sodiumoxide::crypto::sign::ed25519::SecretKey {
+        type Error = Infallible;
+
+        fn public_key(&self) -> PublicKey {
+            PublicKey(self.public_key().0)
+        }
+
+        async fn sign(&self, data: &[u8]) -> Result<Signature, Self::Error> {
+            Ok(Signature(
+                sodiumoxide::crypto::sign::ed25519::sign_detached(data, &self).0,
+            ))
+        }
+    }
+
+    #[async_trait]
     impl Signer
         for (
             sodiumoxide::crypto::sign::ed25519::PublicKey,
@@ -127,9 +142,7 @@ pub mod ed25519 {
         }
 
         async fn sign(&self, data: &[u8]) -> Result<Signature, Self::Error> {
-            Ok(Signature(
-                sodiumoxide::crypto::sign::ed25519::sign_detached(data, &self.1).0,
-            ))
+            self.1.sign(data).await
         }
     }
 

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -150,6 +150,7 @@ pub mod ed25519 {
     mod tests {
         use super::*;
 
+        use ed25519_dalek::Signer as DalekSigner;
         use sodiumoxide::crypto::sign as sodium;
 
         const MESSAGE: &[u8] = b"in a bottle";
@@ -184,8 +185,7 @@ pub mod ed25519 {
             }
 
             async fn sign(&self, data: &[u8]) -> Result<Signature, Self::Error> {
-                let signer: &ed25519_dalek::Keypair = self;
-                Ok(Signature(signer.sign(data).to_bytes()))
+                Ok(Signature(DalekSigner::sign(self, data).to_bytes()))
             }
         }
 


### PR DESCRIPTION
Fixes #3 

Adds the instance of Signer for sodiumoxide's SecretKey. We can then
delegate the sign function, when given the key pair, to use this
instance.