### PR TITLE
Add DynClone to allow us to clone Box<Signer>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 async-trait = "0.1"
+dyn-clone = "1.0"
 futures = "0.3"
 lazy_static = "1.4"
 rpassword = "4.0"

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -25,6 +25,7 @@ pub mod ed25519 {
         hash::{Hash, Hasher},
     };
 
+    use dyn_clone::DynClone;
     use sodiumoxide::utils;
 
     /// Ed25519 public key, encoded as per [RFC 8032]
@@ -102,7 +103,7 @@ pub mod ed25519 {
     }
 
     #[async_trait]
-    pub trait Signer {
+    pub trait Signer: DynClone {
         type Error;
 
         /// Obtain the [`PublicKey`] used for signing


### PR DESCRIPTION
Making this PR to help with the implementation of https://github.com/radicle-dev/radicle-link/pull/255

`DynClone` allows us to call `dyn_clone::clone_box` on a `Box<Signer>` and clone it without needing a `Clone` bound.