### PR TITLE
Derive Clone on storage and Pwhash

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -75,6 +75,7 @@ pub enum SecretBoxError<PinentryError: std::error::Error + 'static> {
 ///
 /// The resulting [`SecretBox`] stores the ciphertext alongside cleartext salt
 /// and nonce values.
+#[derive(Clone)]
 pub struct Pwhash<P> {
     pinentry: P,
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -29,6 +29,7 @@ use crate::{crypto::Crypto, Keypair, Keystore, SecretKeyExt};
 
 /// [`Keystore`] implementation which stores the encrypted key in a file on the
 /// local filesystem.
+#[derive(Clone)]
 pub struct FileStorage<C, PK, SK, M> {
     key_file_path: PathBuf,
     crypto: C,


### PR DESCRIPTION
To help downstream dependencies which require `Clone` on types that hold either of these.