### PR TITLE
Test compatibility with ed25519-zebra

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,7 @@ thiserror = "1.0"
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes"] }
 ed25519-dalek = "=1.0.0-pre.4" # lolwut?
+ed25519-zebra = "2"
+rand = { version = "0.7", default-features = false }
 tempfile = "3"
 


### PR DESCRIPTION
Now that we are using it in `librad`.