### PR TITLE
Migrate to rust-crypto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ secstr = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.10"
 rand = "0.7"
-scrypt = { version = "0.2", default-features = false }
+scrypt = { version = "0.4", default-features = false }
 thiserror = "1.0"
 
 [dependencies.ed25519-zebra]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ secstr = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.10"
 rand = "0.7"
-rust-crypto = "0.2"
+scrypt = { version = "0.2", default-features = false }
 thiserror = "1.0"
 
 [dependencies.ed25519-zebra]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,19 +8,26 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 async-trait = "0.1"
+chacha20poly1305 = { version = "0.5.1", default-features = false, features = ["alloc", "chacha20"] }
 futures = "0.3"
-lazy_static = "1.4"
+generic-array = { version = "0.14", features = ["serde"] }
 rpassword = "4.0"
 secstr = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.10"
-sodiumoxide = "0.2"
+rand = "0.7"
+rust-crypto = "0.2"
 thiserror = "1.0"
+
+[dependencies.ed25519-zebra]
+version = "2.1.2"
+branch = "main"
+git = "https://github.com/radicle-dev/ed25519-zebra"
 
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes"] }
 ed25519-dalek = "=1.0.0-pre.4" # lolwut?
-ed25519-zebra = "2"
 rand = { version = "0.7", default-features = false }
+sodiumoxide = "0.2"
 tempfile = "3"
 

--- a/deny.toml
+++ b/deny.toml
@@ -201,7 +201,5 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
-    "https://github.com/radicle-dev/radicle-surf",
     "https://github.com/radicle-dev/ed25519-zebra",
-    "https://github.com/kim/rustls"
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -202,5 +202,6 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
     "https://github.com/radicle-dev/radicle-surf",
+    "https://github.com/radicle-dev/ed25519-zebra",
     "https://github.com/kim/rustls"
 ]

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -149,8 +149,11 @@ where
 
 fn derive_key(salt: &Salt, passphrase: &SecUtf8) -> [u8; 32] {
     let mut key = [0u8; 32];
-    let params = crypto::scrypt::ScryptParams::new(SCRYPT_WORK_FACTOR, 8, 1);
-    crypto::scrypt::scrypt(passphrase.unsecure().as_bytes(), salt, &params, &mut key);
+    let params =
+        scrypt::ScryptParams::new(SCRYPT_WORK_FACTOR, 8, 1).expect("Scrypt params must be valid");
+
+    scrypt::scrypt(passphrase.unsecure().as_bytes(), salt, &params, &mut key)
+        .expect("Output length must not be zero");
 
     key
 }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -36,7 +36,7 @@ const SCRYPT_WORK_FACTOR: u8 = 16;
 const SCRYPT_WORK_FACTOR: u8 = 4;
 
 /// Nonce used for secret box.
-type Nonce<NonceSize> = GenericArray<u8, NonceSize>;
+type Nonce = GenericArray<u8, <chacha20poly1305::ChaCha20Poly1305 as aead::Aead>::NonceSize>;
 
 /// 192-bit salt.
 type Salt = [u8; 24];
@@ -54,11 +54,8 @@ pub trait Crypto: Sized {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
-pub struct SecretBox<C>
-where
-    C: aead::Aead,
-{
-    nonce: Nonce<C::NonceSize>,
+pub struct SecretBox {
+    nonce: Nonce,
     salt: Salt,
     sealed: Vec<u8>,
 }
@@ -97,7 +94,7 @@ where
     P: Pinentry,
     P::Error: std::error::Error + 'static,
 {
-    type SecretBox = SecretBox<chacha20poly1305::ChaCha20Poly1305>;
+    type SecretBox = SecretBox;
     type Error = SecretBoxError<P::Error>;
 
     fn seal<K: AsRef<[u8]>>(&self, secret: K) -> Result<Self::SecretBox, Self::Error> {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -29,8 +29,11 @@ use crate::pinentry::Pinentry;
 /// Nonce used for secret box.
 type Nonce = GenericArray<u8, <chacha20poly1305::ChaCha20Poly1305 as aead::Aead>::NonceSize>;
 
+/// Size of the salt, in bytes.
+const SALT_SIZE: usize = 24;
+
 /// 192-bit salt.
-type Salt = [u8; 24];
+type Salt = [u8; SALT_SIZE];
 
 /// Class of types which can seal (encrypt) a secret, and unseal (decrypt) it
 /// from it's sealed form.
@@ -106,7 +109,7 @@ where
         rng.fill_bytes(&mut nonce);
 
         // Generate salt.
-        let mut salt: Salt = [0; 24];
+        let mut salt: Salt = [0; SALT_SIZE];
         rng.fill_bytes(&mut salt);
 
         // Derive key from passphrase.


### PR DESCRIPTION
Ok, so this can be summarized with:

```diff
 [dependencies]
+ chacha20poly1305 = { version = "0.5.1", default-features = false, features = ["alloc", "chacha20"] }
+ scrypt = { version = "0.2", default-features = false }
- sodiumoxide = "0.2"
```

* For key derivation, I used `scrypt`, with recommended parameters.
* I didn't end up using `crypto_box` because it seems to be made for a multi-party model by using DH key exchange, which is not what we want here afaict.
* The `nonce` and `salt` sizes are taken from recommended settings, but it's a bit arbitrary to me.
* Randomness comes from `thread_rng` which is supposedly crypto-safe :shrug: 

Before:
```
cargo build  256.96s user 37.24s system 559% cpu 52.583 total
```
After:
```
cargo build  83.57s user 5.61s system 382% cpu 23.297 total
```

Closes #7 