### PR TITLE
Parametrise `Pwhash` over the KDF parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ async-trait = "0.1"
 chacha20poly1305 = { version = "0.5.1", default-features = false, features = ["alloc", "chacha20"] }
 futures = "0.3"
 generic-array = { version = "0.14", features = ["serde"] }
+lazy_static = "1"
 rpassword = "4.0"
 secstr = "0.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/file.rs
+++ b/src/file.rs
@@ -192,7 +192,7 @@ where
 mod tests {
     use super::*;
     use crate::{
-        crypto::{Pwhash, SecretBoxError},
+        crypto::{self, Pwhash, SecretBoxError},
         pinentry::Pinentry,
         test::*,
     };
@@ -206,7 +206,7 @@ mod tests {
         let tmp = tempdir().expect("Can't get tempdir");
         f(FileStorage::new(
             &tmp.path().join("test.key"),
-            Pwhash::new(pin),
+            Pwhash::new(pin, *crypto::KDF_PARAMS_TEST),
         ))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@
 
 #[macro_use]
 extern crate async_trait;
+#[macro_use]
+extern crate lazy_static;
 
 pub use secstr::SecStr;
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -152,7 +152,7 @@ where
 mod tests {
     use super::*;
     use crate::{
-        crypto::{Pwhash, SecretBoxError},
+        crypto::{self, Pwhash, SecretBoxError},
         pinentry::Pinentry,
         test::*,
     };
@@ -163,7 +163,10 @@ mod tests {
         P: Pinentry,
         P::Error: std::error::Error + 'static,
     {
-        f(MemoryStorage::new(Pwhash::new(pin)))
+        f(MemoryStorage::new(Pwhash::new(
+            pin,
+            *crypto::KDF_PARAMS_TEST,
+        )))
     }
 
     #[test]


### PR DESCRIPTION
It turns out that dependent crates will suffer from slowdowns in tests
by an order of magnitude or more, because the test configuration cannot
be applied transitively to dependencies.
