### PR TITLE
Re-instantiate compile-time selection of scrypt params

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,20 @@ authors = ["The Radicle Team <dev@radicle.xyz>"]
 edition = "2018"
 license = "GPL-3.0-or-later"
 
+[features]
+default = []
+# The test feature exists to allow this crate to be configured equivalently to
+# `#[cfg(test)]`, as `#[cfg(test)]` doesn't propagate to dependencies. We use
+# this to employ weaker scrypt params for testing purposes.
+#
+# Using this exploits that cargo will shadow a dependency appearing in
+# `[dependencies]` with the one of the same name appearing in
+# `[dev-dependencies`]. So, to make the tests in `mycrate` (which uses
+# `radicle-keystore`) go faster, add `radicle-keystore` in **both**
+# [`dependencies`] and [`dev-dependencies`], where the latter one is configured
+# with `features = ["test"]`.
+test = []
+
 [dependencies]
 async-trait = "0.1"
 chacha20poly1305 = { version = "0.5.1", default-features = false, features = ["alloc", "chacha20"] }

--- a/src/file.rs
+++ b/src/file.rs
@@ -192,7 +192,7 @@ where
 mod tests {
     use super::*;
     use crate::{
-        crypto::{self, Pwhash, SecretBoxError},
+        crypto::{Pwhash, SecretBoxError},
         pinentry::Pinentry,
         test::*,
     };
@@ -206,7 +206,7 @@ mod tests {
         let tmp = tempdir().expect("Can't get tempdir");
         f(FileStorage::new(
             &tmp.path().join("test.key"),
-            Pwhash::new(pin, *crypto::KDF_PARAMS_TEST),
+            Pwhash::new(pin),
         ))
     }
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -152,7 +152,7 @@ where
 mod tests {
     use super::*;
     use crate::{
-        crypto::{self, Pwhash, SecretBoxError},
+        crypto::{Pwhash, SecretBoxError},
         pinentry::Pinentry,
         test::*,
     };
@@ -163,10 +163,7 @@ mod tests {
         P: Pinentry,
         P::Error: std::error::Error + 'static,
     {
-        f(MemoryStorage::new(Pwhash::new(
-            pin,
-            *crypto::KDF_PARAMS_TEST,
-        )))
+        f(MemoryStorage::new(Pwhash::new(pin)))
     }
 
     #[test]


### PR DESCRIPTION
Employs a trick to convince cargo of using a test configuration (see prose in
Cargo.toml).

---

This trick is courtesy of @CodeSandwich
