### PR TITLE
Be explicit about what scrypt parameters we use for production

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -31,7 +31,7 @@ pub type KdfParams = scrypt::ScryptParams;
 
 lazy_static! {
     /// [`KdfParams`] suitable for production use.
-    pub static ref KDF_PARAMS_PROD: KdfParams = scrypt::ScryptParams::recommended();
+    pub static ref KDF_PARAMS_PROD: KdfParams = scrypt::ScryptParams::new(15, 8, 1).unwrap();
 
     /// [`KdfParams`] suitable for use in tests.
     ///


### PR DESCRIPTION
`scrypt::ScryptParams::recommended()` could change at any point,
breaking downstream users.
