### PR TITLE
ssh: remove depdency on libsodium

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,16 @@ edition = "2018"
 license = "GPL-3.0-or-later"
 
 [features]
-ssh-agent = ["thrussh-keys", "tokio"]
+ssh-agent = ["thrussh-agent", "thrussh-encoding", "tokio"]
+
+[patch.crates-io]
+thrussh-encoding = { git = "https://github.com/FintanH/thrussh.git", branch = "generic-client" , optional = true }
 
 [dependencies]
 async-trait = "0.1"
+byteorder = "1.4"
 chacha20poly1305 = { version = "0.5.1", default-features = false, features = ["alloc", "chacha20"] }
+cryptovec = "0.6.0"
 ed25519-zebra = "2.2"
 futures = "0.3"
 generic-array = { version = "0.14", features = ["serde"] }
@@ -20,7 +25,8 @@ rpassword = "4.0"
 secstr = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.10"
-thrussh-keys = { version = "0.20", optional = true }
+thrussh-agent = { git = "https://github.com/FintanH/thrussh.git", branch = "generic-client" , optional = true }
+thrussh-encoding = { git = "https://github.com/FintanH/thrussh.git", branch = "generic-client" , optional = true }
 tokio = { version = "1.0", features = ["net"], optional = true }
 rand = "0.7"
 scrypt = { version = "0.4", default-features = false }

--- a/ci/build-test
+++ b/ci/build-test
@@ -2,4 +2,4 @@
 set -eou pipefail
 
 echo '--- Build & Test'
-cargo test --all
+cargo test --all --all-features

--- a/examples/ssh-agent.rs
+++ b/examples/ssh-agent.rs
@@ -30,9 +30,7 @@ async fn main() {
         let mut pair = [0u8; 64];
         pair[..32].copy_from_slice(sk.as_ref());
         pair[32..].copy_from_slice(pk.as_ref());
-        ssh::add_key(ssh::SecretKey { key: pair }, &[])
-            .await
-            .unwrap();
+        ssh::add_key(sk, &[]).await.unwrap();
     }
 
     println!("connecting to ssh-agent");


### PR DESCRIPTION
This depends on a proposed change in https://nest.pijul.com/pijul/thrussh/discussions/47.
The patch allows us to avoid the dependency on `thrussh-keys` and
instead rely on a generic client. This means we have to implement some
traits for the zebra keys and signature, but they are very similar to
the implementations for the ed25519 key in thrussh-keys.

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>