### PR TITLE
ssh: use smol over tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 license = "GPL-3.0-or-later"
 
 [features]
-ssh-agent = ["smol", "thrussh-agent", "thrussh-encoding"]
+ssh-agent = ["thrussh-agent", "thrussh-encoding"]
 
 [patch.crates-io]
 thrussh-encoding = { git = "https://github.com/FintanH/thrussh.git", branch = "generic-agent" , optional = true }
@@ -27,14 +27,15 @@ scrypt = { version = "0.4", default-features = false }
 secstr = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.10"
-smol = { version = "1.2", optional = true }
 thiserror = "1.0"
-thrussh-agent = { git = "https://github.com/FintanH/thrussh.git", branch = "generic-agent" , optional = true, features = [ "smol-agent" ], default-features = false }
+thrussh-agent = { git = "https://github.com/FintanH/thrussh.git", branch = "generic-agent" , optional = true, default-features = false }
 thrussh-encoding = { git = "https://github.com/FintanH/thrussh.git", branch = "generic-agent" , optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt"] }
 ed25519-dalek = "=1.0.0-pre.4" # lolwut?
 rand = { version = "0.7", default-features = false }
+smol = { version = "1.2" }
 sodiumoxide = "0.2"
 tempfile = "3"
+thrussh-agent = { git = "https://github.com/FintanH/thrussh.git", branch = "generic-agent" , features = [ "smol-agent" ], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 license = "GPL-3.0-or-later"
 
 [features]
-ssh-agent = ["thrussh-agent", "thrussh-encoding", "tokio"]
+ssh-agent = ["smol", "thrussh-agent", "thrussh-encoding"]
 
 [patch.crates-io]
-thrussh-encoding = { git = "https://github.com/FintanH/thrussh.git", branch = "generic-client" , optional = true }
+thrussh-encoding = { git = "https://github.com/FintanH/thrussh.git", branch = "generic-agent" , optional = true }
 
 [dependencies]
 async-trait = "0.1"
@@ -21,16 +21,16 @@ ed25519-zebra = "2.2"
 futures = "0.3"
 generic-array = { version = "0.14", features = ["serde"] }
 lazy_static = "1"
+rand = "0.7"
 rpassword = "4.0"
+scrypt = { version = "0.4", default-features = false }
 secstr = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.10"
-thrussh-agent = { git = "https://github.com/FintanH/thrussh.git", branch = "generic-client" , optional = true }
-thrussh-encoding = { git = "https://github.com/FintanH/thrussh.git", branch = "generic-client" , optional = true }
-tokio = { version = "1.0", features = ["net"], optional = true }
-rand = "0.7"
-scrypt = { version = "0.4", default-features = false }
+smol = { version = "1.2", optional = true }
 thiserror = "1.0"
+thrussh-agent = { git = "https://github.com/FintanH/thrussh.git", branch = "generic-agent" , optional = true, features = [ "smol-agent" ], default-features = false }
+thrussh-encoding = { git = "https://github.com/FintanH/thrussh.git", branch = "generic-agent" , optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt"] }

--- a/deny.toml
+++ b/deny.toml
@@ -201,5 +201,5 @@ unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
 allow-git = [
-    "https://github.com/radicle-dev/ed25519-zebra",
+    "https://github.com/FintanH/thrussh",
 ]

--- a/examples/ssh-agent.rs
+++ b/examples/ssh-agent.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use smol::io;
+use smol::{io, net::unix::UnixStream};
 
 #[cfg(feature = "ssh-agent")]
 fn main() -> io::Result<()> {
@@ -32,12 +32,12 @@ fn main() -> io::Result<()> {
             let mut pair = [0u8; 64];
             pair[..32].copy_from_slice(sk.as_ref());
             pair[32..].copy_from_slice(pk.as_ref());
-            ssh::add_key(sk, &[]).await.unwrap();
+            ssh::add_key::<UnixStream>(sk, &[]).await.unwrap();
         }
 
         println!("connecting to ssh-agent");
         let agent = SshAgent::new(ssh::ed25519::PublicKey(pk.into()))
-            .connect()
+            .connect::<UnixStream>()
             .await
             .expect("could not connect to ssh-agent");
         println!("asking agent to sign some data");

--- a/examples/ssh-agent.rs
+++ b/examples/ssh-agent.rs
@@ -15,38 +15,42 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use smol::io;
+
 #[cfg(feature = "ssh-agent")]
-#[tokio::main]
-async fn main() {
+fn main() -> io::Result<()> {
     use radicle_keystore::sign::{ssh, Signer, SshAgent};
     use rand::rngs::OsRng;
 
-    let sk = ed25519_zebra::SigningKey::new(OsRng {});
-    let pk = ed25519_zebra::VerificationKey::from(&sk);
+    smol::block_on(async {
+        let sk = ed25519_zebra::SigningKey::new(OsRng {});
+        let pk = ed25519_zebra::VerificationKey::from(&sk);
 
-    // This could be a `rad-ssh-add` executable which reads the local key from
-    // the filestore (prompting for the password).
-    {
-        let mut pair = [0u8; 64];
-        pair[..32].copy_from_slice(sk.as_ref());
-        pair[32..].copy_from_slice(pk.as_ref());
-        ssh::add_key(sk, &[]).await.unwrap();
-    }
+        // This could be a `rad-ssh-add` executable which reads the local key from
+        // the filestore (prompting for the password).
+        {
+            let mut pair = [0u8; 64];
+            pair[..32].copy_from_slice(sk.as_ref());
+            pair[32..].copy_from_slice(pk.as_ref());
+            ssh::add_key(sk, &[]).await.unwrap();
+        }
 
-    println!("connecting to ssh-agent");
-    let agent = SshAgent::new(ssh::ed25519::PublicKey(pk.into()))
-        .connect()
-        .await
-        .expect("could not connect to ssh-agent");
-    println!("asking agent to sign some data");
-    let sig = agent
-        .sign(b"cooper")
-        .await
-        .expect("signing via ssh-agent failed");
-    println!("verifying signature");
-    pk.verify(&ed25519_zebra::Signature::from(sig.0), b"cooper")
-        .expect("ssh-agent didn't return a valid signature");
-    println!("it worksed");
+        println!("connecting to ssh-agent");
+        let agent = SshAgent::new(ssh::ed25519::PublicKey(pk.into()))
+            .connect()
+            .await
+            .expect("could not connect to ssh-agent");
+        println!("asking agent to sign some data");
+        let sig = agent
+            .sign(b"cooper")
+            .await
+            .expect("signing via ssh-agent failed");
+        println!("verifying signature");
+        pk.verify(&ed25519_zebra::Signature::from(sig.0), b"cooper")
+            .expect("ssh-agent didn't return a valid signature");
+        println!("it worksed");
+        Ok(())
+    })
 }
 
 #[cfg(not(feature = "ssh-agent"))]


### PR DESCRIPTION
This removes the need for a tokio dependency and instead uses smol as
dependency for the async runtime. It depends on a patch that only exists
in the git fork for now.

Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>