### PR TITLE
ci: use "tool-cache" for cargo install action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,7 @@ jobs:
         with:
           crate: cargo-deny
           version: latest
+          use-tool-cache: true
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
         with:
@@ -69,6 +70,7 @@ jobs:
         with:
           crate: cargo-deny
           version: latest
+          use-tool-cache: true
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Avoid re-installing cargo-deny by opting into the "tool-cache". The
security warnings have been considered: we do not expose secrets to our
builds, so in case of a breach we risk getting false or no warnings from
`cargo deny`, which is acceptable.

Signed-off-by: Kim Altintop <kim@monadic.xyz>