### PR TITLE
Constrain `Signer::Error`

### DIFF
--- a/src/sign/ed25519.rs
+++ b/src/sign/ed25519.rs
@@ -107,7 +107,7 @@ impl Debug for Signature {
 
 #[async_trait]
 pub trait Signer {
-    type Error;
+    type Error: std::error::Error + Send + Sync + 'static;
 
     /// Obtain the [`PublicKey`] used for signing
     fn public_key(&self) -> PublicKey;


### PR DESCRIPTION
In practice, most errors need to satisfy:

    std::error::Error + Send + Sync + 'static

and `Signer::Error` is no exception.

By defining the bound on the trait here, some wild tricks involving
associated type bounds can be removed from `link-crypto`. This lets us
avoid a compiler bug in recent `rustc`s [0] without compromising
errrrgonomics.

[0]: https://github.com/rust-lang/rust/issues/90691
