### PR TITLE
ci: use cargo-deny GH action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,68 +20,19 @@ jobs:
       - run: ./ci/clippy
         shell: bash
 
-  # Hilariously, we cannot usually do anything about security advisories,
-  # because they typically affect transitive dependencies. Thus, allow this job
-  # to fail, but keep it around hoping for a nudging effect.
-  advisories:
+  cargo-deny:
     runs-on: ubuntu-latest
-    continue-on-error: true
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v2
+      - uses: EmbarkStudios/cargo-deny-action@v1
         with:
-          path: |
-            ~/.rustup/settings.toml
-            ~/.rustup/toolchains
-            ~/.rustup/update-hashes
-          key: toolchain-${{ hashFiles('rust-toolchain') }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          components: rustfmt, clippy
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-deny
-          version: latest
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: deny
-          args: check advisories
-
-  # cargo deny checks which ought to pass
-  compliance:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.rustup/settings.toml
-            ~/.rustup/toolchains
-            ~/.rustup/update-hashes
-          key: toolchain-${{ hashFiles('rust-toolchain') }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          components: rustfmt, clippy
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-deny
-          version: latest
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: deny
-          args: check licenses
-      - uses: actions-rs/cargo@v1
-        with:
-          command: deny
-          args: check bans
-      - uses: actions-rs/cargo@v1
-        with:
-          command: deny
-          args: check sources
+          command: check ${{ matrix.checks }}
 
   build-test:
     strategy:


### PR DESCRIPTION
Installs a precompiled `cargo-deny`, which should save some time and allows to yolo over the edition upgrade of deny.
