### PR TITLE
add key comment for GnuPG SSH agent

### DIFF
--- a/src/sign/ed25519.rs
+++ b/src/sign/ed25519.rs
@@ -263,7 +263,9 @@ pub mod thrussh {
             buf.extend_ssh_string(pk.as_ref());
             buf.push_u32_be(64);
             buf.extend(&pair);
-            buf.extend_ssh_string(b"");
+            // The GnuPG SSH agent fails to add keys with empty comments.
+            // See: https://dev.gnupg.org/T5794
+            buf.extend_ssh_string(b"radicle ed25519-zebra");
             Ok(())
         }
 


### PR DESCRIPTION
Add a key comment when adding a key to the SSH agent. This is necessary because the GnuPG implementation of the SSH agent cannot add keys that have empty comments. See https://dev.gnupg.org/T5794

At first, I wanted to use the peer ID as the key comment. But unfortunately, there’s no code in this crate that converts a key to the peer ID and using a `radicle-link` crate would create a circular dependency.