### PR TITLE
Relax crypto in lib and fix-bump chacha20poly1305

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,22 +27,20 @@ thiserror = "1.0"
 
 # CRYPTO
 #
-# NOTE: by policy, we pin non-dev cryptographic libraries to their exact
-# versions, requiring explicit maintainer action to apply upgrades. The
-# `deny.toml` is set up such that unintended upgrades are (hopefully) rejected.
+# The binary consumer dictates these versions via .lock
+# The .lock is used to screen the crypto dependency minor/patch bumps
 #
 [dependencies.chacha20poly1305]
-version = "=0.9.0"
+version = "^0.10.1"
 default-features = false
 features = ["alloc"]
 
 [dependencies.ed25519-zebra]
-version = "=3.0.0"
+version = "^3.0.0"
 
 [dependencies.scrypt]
-version = "=0.8.0"
+version = "^0.10.0"
 default-features = false
-# END CRYPTO
 
 [dev-dependencies]
 tokio = { version = ">= 1.8.4", features = ["macros", "rt"] }

--- a/deny.toml
+++ b/deny.toml
@@ -165,10 +165,6 @@ deny = [
     # Each entry the name of a crate and a version range. If version is
     # not specified, all versions will be matched.
     #{ name = "ansi_term", version = "=0.11.0" },
-    { name = "chacha20poly1305", version = "> 0.9.0" },
-    { name = "ed25519-zebra", version = "> 3.0.0" },
-    { name = "curve25519-dalek", version = "> 3.2.0" },
-    { name = "scrypt", version = "> 0.8.0" },
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -15,10 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use chacha20poly1305::{
-    aead,
-    aead::{Aead, NewAead},
-};
+use chacha20poly1305::{aead, aead::Aead, KeyInit};
 use generic_array::GenericArray;
 use secstr::{SecStr, SecUtf8};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Signed-off-by: pinkforest <36498018+pinkforest@users.noreply.github.com>

The library pinning has side effect of where multiple versions of crypto is used when the dependencies are not updated here

It is best to screen the version via .lock changes in binary and not try to paper cut commit the library by pinning it here

I described it in depth here: https://github.com/radicle-dev/radicle-cli/issues/248#issuecomment-1245060924

Otherwise:

- chacha20poly1305 minimum to 0.10.1 + deal with API change
- ed25519-zebra keep 3.0.0 as minimum
- scrypt - this caused the most problems relax to minimum 0.10.0